### PR TITLE
chore: show warn message when don't have docs to send

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -115,6 +115,10 @@ const indexDocuments = async ({
   verbose,
   reporter,
 }) => {
+  if(!docs || !docs.length) {
+    reporter.warn(`Skipped: No docs to reindex`)
+    return Promise.resolve({})
+  }
   const url = `https://${serviceName}.search.windows.net/indexes/${indexName}/docs/index?api-version=${API_VERSION}`;
   const body = {
     value: docs,


### PR DESCRIPTION
When the configured query don't return results the Gatsby build fails with an error like: `Faield to index documents: Request failed with status code 400` 

I think that is better show a warning in this cases and don't broke the build.